### PR TITLE
revert: "always include debug info in bytecode"

### DIFF
--- a/lib/CompilerDriver/CompilerDriver.cpp
+++ b/lib/CompilerDriver/CompilerDriver.cpp
@@ -1958,7 +1958,8 @@ CompileResult processSourceFiles(
 
   // If the user requests to output a source map, then do not also emit debug
   // info into the bytecode.
-  genOptions.stripDebugInfoSection = false;
+  genOptions.stripDebugInfoSection =
+      cl::OutputSourceMap || cl::DebugInfoLevel == cl::DebugLevel::g0;
 
   genOptions.stripFunctionNames = cl::StripFunctionNames;
 


### PR DESCRIPTION
This reverts commit aac1f5b3f99690cc90202fb576cf6d37dc1613f1, we've decided to include that debug info via build tooling around hermesc rather than changes to hermesc itself


<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/hermes) and create your branch from `main`.
  2. If you've fixed a bug or added code that should be tested, add tests!
  3. Ensure it builds and the test suite passes. [tips](https://github.com/facebook/hermes/blob/HEAD/doc/BuildingAndRunning.md)
  4. Format your code with `.../hermes/utils/format.sh`
  5. If you haven't already, complete the CLA.
-->

## Summary

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
-->

## Test Plan

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes the user interface.
-->