### PR TITLE
fix: add back mac framework in builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,6 +137,8 @@ jobs:
         sudo gem install cocoapods
     - name: Build the iOS frameworks
       run: "./utils/build-ios-framework.sh"
+    - name: Build the Mac frameworks
+      run: "./utils/build-mac-framework.sh"
   package-apple-runtime:
     runs-on: macos-14
     needs:


### PR DESCRIPTION
## Summary

Adds back the bin dir to destroot with mac framework stuff

## Test Plan

- [ ] destroot/bin/hermesc exists
