### PR TITLE
fix: add apple builds debug symbols

### DIFF
--- a/API/hermes/CMakeLists.txt
+++ b/API/hermes/CMakeLists.txt
@@ -92,7 +92,7 @@ if(APPLE AND HERMES_BUILD_APPLE_FRAMEWORK)
     target_link_options(libhermes PUBLIC "-fembed-bitcode")
   endif()
   # Strip the LC_UUID from the framework binary
-  target_link_options(libhermes PRIVATE "-Wl,-no_uuid")
+  # target_link_options(libhermes PRIVATE "-Wl,-no_uuid")
   # Define the deployment target in the frameworks metadata
   if(HERMES_APPLE_TARGET_PLATFORM MATCHES "iphone")
     add_custom_command(TARGET libhermes POST_BUILD

--- a/utils/build-apple-framework.sh
+++ b/utils/build-apple-framework.sh
@@ -100,7 +100,8 @@ function create_universal_framework {
   echo "Creating universal framework for platforms: ${platforms[*]}"
 
   for i in "${!platforms[@]}"; do
-    args+="-framework ${platforms[$i]}/hermes.framework "
+    args+="-framework $(readlink -f ${platforms[$i]}/hermes.framework) "
+    args+="-debug-symbols $(readlink -f ${platforms[$i]}/hermes.framework.dSYM) "
   done
 
   mkdir universal


### PR DESCRIPTION
## Summary

This PR disables the determinism fix for the UUID - so builds will be slightly indeterministic by 32 bytes or something but verifiably the UUID. We can technically patch this with a script if we want to.

We add the dSYM to the universal build, had to add readlink because it didn't want to play ball, seems like xcodebuild doesn't like symlinks when building frameworks.

## Test Plan

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes the user interface.
-->
