### PR TITLE
fix: brownout ubuntu

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -186,7 +186,7 @@ jobs:
         name: apple-runtime
         path: /tmp/hermes/output/
   npm:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs:
     - android
     - linux


### PR DESCRIPTION
## Summary

Fixes the brownout for ubuntu

## Test Plan

CI ubuntu brownout not complaining / cancel npm action
