### PR TITLE
fix: pin NDK & CMake & reproducible

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
         cmake -S hermes -B build
         # Build the Hermes compiler so that the cross compiler build can
         # access it to build the VM
-        cmake --build ./build --target hermesc -j 4
+        cmake --build $HERMES_WS_DIR/build --target hermesc -j 4
     - name: Build Hermes for Android
       run: |-
         cd hermes/android
@@ -29,7 +29,7 @@ jobs:
     - name: Copy artifacts
       run: |-
         mkdir output
-        cp build_android/distributions/hermes-runtime-android-*.tar.gz output
+        cp $HERMES_WS_DIR/build_android/distributions/hermes-runtime-android-*.tar.gz output
     - name: Checksum artifacts
       run: |-
         cd output

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
   android:
     runs-on: ubuntu-22.04
     env:
-      HERMES_WS_DIR: ${{ github.workspace }}
+      HERMES_WS_DIR: "/tmp/hermes"
     steps:
     - name: Set up workspace and install dependencies
       run: |-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,6 @@ jobs:
     steps:
     - name: Set up workspace and install dependencies
       run: |-
-        yes | sdkmanager "cmake;3.22.1" &
         sudo apt update && sudo apt install -y libicu-dev
     - uses: actions/checkout@v4.1.0
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
         path: hermes
     - name: Build Hermes Compiler
       run: |-
-        cmake -S hermes -B build
+        cmake -S hermes -B $HERMES_WS_DIR/build
         # Build the Hermes compiler so that the cross compiler build can
         # access it to build the VM
         cmake --build $HERMES_WS_DIR/build --target hermesc -j 4

--- a/android/hermes-engine/build.gradle
+++ b/android/hermes-engine/build.gradle
@@ -12,6 +12,7 @@ buildDir.mkdirs()
 
 android {
   compileSdkVersion = rootProject.ext.compileSdkVersion
+  ndkVersion '27.2.12479018'
 
   defaultConfig {
     minSdkVersion rootProject.ext.minSdkVersion
@@ -36,7 +37,7 @@ android {
 
   externalNativeBuild {
     cmake {
-      version "3.18.1"
+      version "3.22.1"
       path "../../CMakeLists.txt"
       buildStagingDirectory = "${rootProject.ext.hermes_ws}/staging/hermes"
       buildStagingDirectory.mkdirs()

--- a/android/hermes-engine/build.gradle
+++ b/android/hermes-engine/build.gradle
@@ -52,7 +52,7 @@ android {
           arguments "-DCMAKE_BUILD_TYPE=Release"
           // This overrides CMAKE_SHARED_LINKER_FLAGS, it does not 
           // append to it. This is fine for now since it is unused.
-          arguments "-DCMAKE_SHARED_LINKER_FLAGS=-Wl,--strip-all,--build-id=none"
+          arguments "-DCMAKE_SHARED_LINKER_FLAGS=-fuse-ld=lld -Wl,--strip-all,--build-id=none"
         }
       }
     }
@@ -63,7 +63,7 @@ android {
           arguments "-DCMAKE_BUILD_TYPE=MinSizeRel"
           // This overrides CMAKE_SHARED_LINKER_FLAGS, it does not 
           // append to it. This is fine for now since it is unused.
-          arguments "-DCMAKE_SHARED_LINKER_FLAGS=-Wl,--strip-all,--build-id=none"
+          arguments "-DCMAKE_SHARED_LINKER_FLAGS=-fuse-ld=lld -Wl,--strip-all,--build-id=none"
         }
       }
     }

--- a/android/hermes-engine/build.gradle
+++ b/android/hermes-engine/build.gradle
@@ -12,7 +12,7 @@ buildDir.mkdirs()
 
 android {
   compileSdkVersion = rootProject.ext.compileSdkVersion
-  ndkVersion '27.2.12479018'
+  ndkVersion '26.3.11579264'
 
   defaultConfig {
     minSdkVersion rootProject.ext.minSdkVersion

--- a/android/hermes-engine/build.gradle
+++ b/android/hermes-engine/build.gradle
@@ -10,6 +10,13 @@ apply plugin: 'com.android.library'
 buildDir = "${rootProject.ext.hermes_ws}/build_android/hermes"
 buildDir.mkdirs()
 
+def getHostTag() {
+  def os = System.getProperty("os.name").toLowerCase()
+  if (os.contains("mac")) return "darwin-x86_64"
+  if (os.contains("win")) return "windows-x86_64"
+  return "linux-x86_64"
+}
+
 android {
   compileSdkVersion = rootProject.ext.compileSdkVersion
   ndkVersion '27.2.12479018'
@@ -52,7 +59,7 @@ android {
           arguments "-DCMAKE_BUILD_TYPE=Release"
           // This overrides CMAKE_SHARED_LINKER_FLAGS, it does not 
           // append to it. This is fine for now since it is unused.
-          arguments "-DCMAKE_SHARED_LINKER_FLAGS=-fuse-ld=lld -Wl,--strip-all,--build-id=none"
+          arguments "-DCMAKE_SHARED_LINKER_FLAGS=-Wl,--strip-all,--build-id=none"
         }
       }
     }
@@ -63,7 +70,7 @@ android {
           arguments "-DCMAKE_BUILD_TYPE=MinSizeRel"
           // This overrides CMAKE_SHARED_LINKER_FLAGS, it does not 
           // append to it. This is fine for now since it is unused.
-          arguments "-DCMAKE_SHARED_LINKER_FLAGS=-fuse-ld=lld -Wl,--strip-all,--build-id=none"
+          arguments "-DCMAKE_SHARED_LINKER_FLAGS=-Wl,--strip-all,--build-id=none"
         }
       }
     }
@@ -123,6 +130,25 @@ android {
     libhermes {
       headers "$buildDir/../outputs/include"
       libraryName "libhermes"
+    }
+  }
+
+  tasks.whenTaskAdded { task ->
+    if (task.name.startsWith("externalNativeBuild")) {
+      task.doLast {
+        rootProject.ext.abis.each { abi ->
+          def soDir = file("${buildDir}/intermediates/cmake/intlRelease/obj/${abi}")
+          if (soDir.exists()) {
+            soDir.eachFileMatch(~/.*\.so/) { File soFile ->
+              println "Stripping ${soFile.name} for ABI ${abi}"
+              exec {
+                executable "${android.ndkDirectory}/toolchains/llvm/prebuilt/${getHostTag()}/bin/llvm-strip"
+                args "--strip-all", soFile.absolutePath
+              }
+            }
+          }
+        }
+      }
     }
   }
 

--- a/android/hermes-engine/build.gradle
+++ b/android/hermes-engine/build.gradle
@@ -52,7 +52,7 @@ android {
           arguments "-DCMAKE_BUILD_TYPE=Release"
           // This overrides CMAKE_SHARED_LINKER_FLAGS, it does not 
           // append to it. This is fine for now since it is unused.
-          arguments "-DCMAKE_SHARED_LINKER_FLAGS=-Wl,--strip-all"
+          arguments "-DCMAKE_SHARED_LINKER_FLAGS=-Wl,--strip-all,--build-id=none"
         }
       }
     }
@@ -63,7 +63,7 @@ android {
           arguments "-DCMAKE_BUILD_TYPE=MinSizeRel"
           // This overrides CMAKE_SHARED_LINKER_FLAGS, it does not 
           // append to it. This is fine for now since it is unused.
-          arguments "-DCMAKE_SHARED_LINKER_FLAGS=-Wl,--strip-all"
+          arguments "-DCMAKE_SHARED_LINKER_FLAGS=-Wl,--strip-all,--build-id=none"
         }
       }
     }

--- a/android/hermes-engine/build.gradle
+++ b/android/hermes-engine/build.gradle
@@ -19,7 +19,7 @@ def getHostTag() {
 
 android {
   compileSdkVersion = rootProject.ext.compileSdkVersion
-  ndkVersion '27.2.12479018'
+  ndkVersion '23.1.7779620'
 
   defaultConfig {
     minSdkVersion rootProject.ext.minSdkVersion

--- a/android/hermes-engine/build.gradle
+++ b/android/hermes-engine/build.gradle
@@ -12,7 +12,7 @@ buildDir.mkdirs()
 
 android {
   compileSdkVersion = rootProject.ext.compileSdkVersion
-  ndkVersion '26.3.11579264'
+  ndkVersion '27.2.12479018'
 
   defaultConfig {
     minSdkVersion rootProject.ext.minSdkVersion
@@ -37,7 +37,7 @@ android {
 
   externalNativeBuild {
     cmake {
-      version "3.22.1"
+      version "3.18.1"
       path "../../CMakeLists.txt"
       buildStagingDirectory = "${rootProject.ext.hermes_ws}/staging/hermes"
       buildStagingDirectory.mkdirs()

--- a/npm/hermes-engine/package.json
+++ b/npm/hermes-engine/package.json
@@ -10,7 +10,6 @@
   },
   "files": [
     "README.md",
-    "android/hermes-debug.aar",
     "android/hermes-release.aar",
     "android/include/**/*.h",
     "linux64-bin/hermesc",


### PR DESCRIPTION
## Summary

This PR pins:

* CMake to 3.18.1 (tried 3.22.1 but that errors with riscv64)
* NDK to 23.1.7779620
* removes debug.aar which is unused
* reproducibility: strip the GNU build id & call llvm-strip to remove inconsistent debug symbol information 

## Test Plan

- [ ] CI passes
- [ ] Build works on mobile
